### PR TITLE
Allow for conditional forwarding to fallback upstream

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -50,6 +50,7 @@ blocky__upstreams:
 blocky__custom_dns: {}
 # web1.example.com: 10.100.1.2
 
+blocky__custom_domain_fallback_upstream: false
 blocky__custom_domain: {}
 # lan: 10.100.1.1
 

--- a/templates/config_base.j2
+++ b/templates/config_base.j2
@@ -72,7 +72,7 @@ customDNS:
 
 {% block conditional -%}
 conditional:
-  fallbackUpstream: false
+  fallbackUpstream: {{ blocky__custom_domain_fallback_upstream | lower }}
   mapping:
     {{ blocky__custom_domain | to_nice_yaml(indent=2) | trim | indent(4) }}
 {% endblock %}


### PR DESCRIPTION
This is a simple PR to allow for conditional forwarding (custom domains) to fallback upstream as i wanted to enable that on my instance.

The relevant Blocky docs can be found here: https://0xerr0r.github.io/blocky/latest/configuration/#conditional-dns-resolution