### PR TITLE
fix: Timeout while waiting for blocky to get ready with many/long blocklists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           # Temporarily disabled due to "sudo: A password is required" error, see https://github.com/geerlingguy/docker-rockylinux9-ansible/issues/6
           #- rockylinux9
         blocky_version:
+          - v0.26
+          - v0.25
           - v0.24
           - v0.23
           - v0.22

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -118,4 +118,5 @@
     port: "{{ (blocky__ports_dns | string | ansible.builtin.split(':') | last) if ':' in blocky__ports_dns | string else blocky__ports_dns }}"
     delay: 5
     timeout: 30
+  retries: 5
   when: blocky__readiness_check_enabled

--- a/templates/config_base.j2
+++ b/templates/config_base.j2
@@ -71,8 +71,10 @@ customDNS:
 {% endblock %}
 
 {% block bootstrap_dns -%}
+{% if blocky__bootstrap_dns | length > 0 %}
 bootstrapDns:
   {{ blocky__bootstrap_dns | to_nice_yaml(indent=2) | trim | indent(2) }}
+{% endif %}
 {% endblock %}
 
 {% block conditional -%}


### PR DESCRIPTION
If blocky is configured with a large number of lists, startup (and downloading/parsing the lists) can take minutes, especially if there are list URLs which might no longer be active and result in a timeout.
This change adds up to 5 retries to the 30s readiness check, effectively increasing the timeout to 150s.