### PR TITLE
feat: add queryLog configuration support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -91,3 +91,22 @@ blocky__min_tls_version: ""
 blocky__redis: {}
 
 blocky__bootstrap_dns: {}
+
+# Query logging - https://0xerr0r.github.io/blocky/latest/configuration/#query-logging
+# Set blocky__query_log_type to enable query logging.
+# Supported types: mysql, postgresql, timescale, csv, csv-client, console, none
+# Leave empty to disable the queryLog section entirely.
+blocky__query_log_type: ""
+# Database connection string (for mysql/postgresql/timescale) or directory path (for csv/csv-client).
+blocky__query_log_target: ""
+# Delete log entries older than this many days. 0 = keep forever.
+blocky__query_log_log_retention_days: 0
+# Maximum number of attempts to create the log writer on startup.
+blocky__query_log_creation_attempts: 3
+# Cooldown duration between log writer creation retry attempts.
+blocky__query_log_creation_cooldown: 2s
+# Fields to include in log entries. Empty list = log all fields.
+# Valid values: clientIP, clientName, responseReason, responseAnswer, question, duration
+blocky__query_log_fields: []
+# How often to flush buffered data to the external database (database types only).
+blocky__query_log_flush_interval: 30s

--- a/templates/config.yaml.j2
+++ b/templates/config.yaml.j2
@@ -103,3 +103,21 @@ prometheus:
 redis:
   {{ blocky__redis | to_nice_yaml(indent=2) | trim | indent(2) }}
 {% endblock %}
+
+{% block query_log -%}
+{% if blocky__query_log_type | default('') | trim %}
+queryLog:
+  type: {{ blocky__query_log_type }}
+{% if blocky__query_log_target | default('') | trim %}
+  target: "{{ blocky__query_log_target }}"
+{% endif %}
+  logRetentionDays: {{ blocky__query_log_log_retention_days }}
+  creationAttempts: {{ blocky__query_log_creation_attempts }}
+  creationCooldown: {{ blocky__query_log_creation_cooldown }}
+{% if blocky__query_log_fields %}
+  fields:
+    {{ blocky__query_log_fields | to_nice_yaml(indent=2) | trim | indent(4) }}
+{% endif %}
+  flushInterval: {{ blocky__query_log_flush_interval }}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
Add variables and template block to configure Blocky's query logging feature, supporting all backends (postgresql, mysql, timescale, csv, csv-client, console) with all available options.

New defaults:
- blocky__query_log_type: enable logging by setting to a supported type
- blocky__query_log_target: DB connection string or CSV directory path
- blocky__query_log_log_retention_days: auto-delete logs older than N days
- blocky__query_log_creation_attempts: retries on startup
- blocky__query_log_creation_cooldown: delay between retries
- blocky__query_log_fields: subset of fields to log (empty = all)
- blocky__query_log_flush_interval: bulk write interval for DB backends

The queryLog section is only emitted when blocky__query_log_type is set, making this fully backwards-compatible with existing deployments.